### PR TITLE
Fix Supabase API calls and add user management features

### DIFF
--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -23,11 +23,11 @@ export interface ProcessoAPI {
 }
 
 export async function fetchEmployees() {
-  const { data: employees, error: empErr } = await supabase.from<FuncionarioAPI>("employees").select("*");
+  const { data: employees, error: empErr } = await supabase.from("employees").select("*");
   if (empErr) throw empErr;
 
-  const { data: processes } = await supabase.from<ProcessoAPI>("processes").select("*");
-  const { data: profiles } = await supabase.from<any>("profiles").select("*");
+  const { data: processes } = await supabase.from("processes").select("*");
+  const { data: profiles } = await supabase.from("profiles").select("*");
 
   const profilesMap = new Map<string, any>();
   profiles?.forEach((p) => profilesMap.set(p.id, p));
@@ -55,7 +55,7 @@ export async function fetchEmployees() {
 }
 
 export async function fetchEmployeeById(matriculaOrId: string) {
-  const { data: employees } = await supabase.from<FuncionarioAPI>("employees").select("*").or(`matricula.eq.${matriculaOrId},id.eq.${matriculaOrId}`);
+  const { data: employees } = await supabase.from("employees").select("*").or(`matricula.eq.${matriculaOrId},id.eq.${matriculaOrId}`);
   const emp = employees?.[0];
   if (!emp) return undefined;
   const employeesMapped = await fetchEmployees();
@@ -63,7 +63,7 @@ export async function fetchEmployeeById(matriculaOrId: string) {
 }
 
 export async function fetchProcesses() {
-  const { data: processes } = await supabase.from<ProcessoAPI>("processes").select("*");
+  const { data: processes } = await supabase.from("processes").select("*");
   const { data: employees } = await supabase.from<FuncionarioAPI>("employees").select("*");
   const empMap = new Map<string, string>();
   (employees || []).forEach((e) => empMap.set(e.id, e.nome_completo ?? e.matricula ?? ""));
@@ -83,7 +83,7 @@ export async function fetchProcessById(id: string) {
   const { data: processes } = await supabase.from<ProcessoAPI>("processes").select("*").eq("id", id);
   if (!processes || processes.length === 0) return undefined;
   const p = processes[0];
-  const { data: employee } = await supabase.from<FuncionarioAPI>("employees").select("*").eq("id", p.employee_id).limit(1).single();
+  const { data: employee } = await supabase.from("employees").select("*").eq("id", p.employee_id).limit(1).single();
   return {
     id: p.id,
     funcionario: employee?.nome_completo ?? "",
@@ -96,7 +96,7 @@ export async function fetchProcessById(id: string) {
 }
 
 export async function fetchUsers() {
-  const { data: profiles } = await supabase.from<any>("profiles").select("*");
+  const { data: profiles } = await supabase.from("profiles").select("*");
   return (profiles || []).map((p) => ({
     id: p.id,
     nome: p.nome ?? "",

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -64,7 +64,7 @@ export async function fetchEmployeeById(matriculaOrId: string) {
 
 export async function fetchProcesses() {
   const { data: processes } = await supabase.from("processes").select("*");
-  const { data: employees } = await supabase.from<FuncionarioAPI>("employees").select("*");
+  const { data: employees } = await supabase.from("employees").select("*");
   const empMap = new Map<string, string>();
   (employees || []).forEach((e) => empMap.set(e.id, e.nome_completo ?? e.matricula ?? ""));
 
@@ -80,7 +80,7 @@ export async function fetchProcesses() {
 }
 
 export async function fetchProcessById(id: string) {
-  const { data: processes } = await supabase.from<ProcessoAPI>("processes").select("*").eq("id", id);
+  const { data: processes } = await supabase.from("processes").select("*").eq("id", id);
   if (!processes || processes.length === 0) return undefined;
   const p = processes[0];
   const { data: employee } = await supabase.from("employees").select("*").eq("id", p.employee_id).limit(1).single();

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -75,6 +75,7 @@ export async function fetchProcesses() {
     classificacao: p.classificacao ? (p.classificacao === "Media" ? "Média" : p.classificacao) : ("Leve" as any),
     dataAbertura: p.created_at ? new Date(p.created_at).toLocaleDateString() : "",
     status: p.status ? p.status.replace(/_/g, " ") : ("Em Análise" as any),
+    resolucao: p.resolucao ?? "",
   }));
 }
 

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -90,6 +90,7 @@ export async function fetchProcessById(id: string) {
     classificacao: p.classificacao ? (p.classificacao === "Media" ? "Média" : p.classificacao) : ("Leve" as any),
     dataAbertura: p.created_at ? new Date(p.created_at).toLocaleDateString() : "",
     status: p.status ? p.status.replace(/_/g, " ") : ("Em Análise" as any),
+    resolucao: p.resolucao ?? "",
   };
 }
 

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -94,7 +94,6 @@ export async function fetchProcessById(id: string) {
 }
 
 export async function fetchUsers() {
-  // Supabase public anon key cannot list auth.users; use profiles table as source of truth
   const { data: profiles } = await supabase.from<any>("profiles").select("*");
   return (profiles || []).map((p) => ({
     id: p.id,
@@ -105,4 +104,15 @@ export async function fetchUsers() {
     criadoEm: p.created_at ?? new Date().toISOString(),
     ultimoAcesso: null,
   }));
+}
+
+export type PerfilUsuario = "administrador" | "gestor" | "juridico" | "funcionario";
+export async function updateProfile(id: string, patch: { nome?: string; perfil?: PerfilUsuario; ativo?: boolean }) {
+  const { error } = await supabase.from("profiles").update(patch as any).eq("id", id);
+  if (error) throw error;
+}
+
+export async function updateProcess(id: string, patch: Partial<ProcessoAPI>) {
+  const { error } = await supabase.from("processes").update(patch as any).eq("id", id);
+  if (error) throw error;
 }

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -74,6 +74,7 @@ export async function fetchProcesses() {
     tipoDesvio: p.tipo_desvio ?? "",
     classificacao: p.classificacao ? (p.classificacao === "Media" ? "Média" : p.classificacao) : ("Leve" as any),
     dataAbertura: p.created_at ? new Date(p.created_at).toLocaleDateString() : "",
+    createdAt: p.created_at ?? null,
     status: p.status ? p.status.replace(/_/g, " ") : ("Em Análise" as any),
     resolucao: p.resolucao ?? "",
   }));
@@ -90,6 +91,7 @@ export async function fetchProcessById(id: string) {
     tipoDesvio: p.tipo_desvio ?? "",
     classificacao: p.classificacao ? (p.classificacao === "Media" ? "Média" : p.classificacao) : ("Leve" as any),
     dataAbertura: p.created_at ? new Date(p.created_at).toLocaleDateString() : "",
+    createdAt: p.created_at ?? null,
     status: p.status ? p.status.replace(/_/g, " ") : ("Em Análise" as any),
     resolucao: p.resolucao ?? "",
   };

--- a/client/lib/supabase.ts
+++ b/client/lib/supabase.ts
@@ -3,11 +3,52 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl) {
-  throw new Error('VITE_SUPABASE_URL is not set');
-}
-if (!supabaseKey) {
-  throw new Error('VITE_SUPABASE_ANON_KEY is not set');
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseKey);
+
+function createNotConfiguredClient() {
+  const message =
+    'Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable authentication and data features.';
+
+  const auth = {
+    async signInWithPassword() {
+      return { data: null, error: { message } };
+    },
+    async getUser() {
+      return { data: { user: null }, error: { message } };
+    },
+  };
+
+  const chain = () => ({
+    select() {
+      return chain();
+    },
+    eq() {
+      return chain();
+    },
+    ilike() {
+      return chain();
+    },
+    limit() {
+      return chain();
+    },
+    async maybeSingle() {
+      return { data: null, error: { message } };
+    },
+    async then() {
+      return { data: null, error: { message } } as any;
+    },
+  });
+
+  const from = () => chain();
+
+  if (typeof window !== 'undefined') {
+    // eslint-disable-next-line no-console
+    console.warn('[Supabase] ' + message);
+  }
+
+  return { auth, from } as any;
 }
 
-export const supabase = createClient(supabaseUrl, supabaseKey);
+export const supabase = isSupabaseConfigured
+  ? createClient(supabaseUrl as string, supabaseKey as string)
+  : createNotConfiguredClient();

--- a/client/lib/supabase.ts
+++ b/client/lib/supabase.ts
@@ -34,8 +34,13 @@ function createNotConfiguredClient() {
     async maybeSingle() {
       return { data: null, error: { message } };
     },
-    async then() {
-      return { data: null, error: { message } } as any;
+    then(onFulfilled?: (value: any) => any, onRejected?: (reason: any) => any) {
+      const value = { data: null, error: { message } } as const;
+      try {
+        return Promise.resolve(onFulfilled ? onFulfilled(value) : (value as any));
+      } catch (err) {
+        return onRejected ? Promise.resolve(onRejected(err)) : Promise.reject(err);
+      }
     },
   });
 

--- a/client/lib/supabase.ts
+++ b/client/lib/supabase.ts
@@ -1,59 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
-export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseKey);
-
-function createNotConfiguredClient() {
-  const message =
-    'Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable authentication and data features.';
-
-  const auth = {
-    async signInWithPassword() {
-      return { data: null, error: { message } };
-    },
-    async getUser() {
-      return { data: { user: null }, error: { message } };
-    },
-  };
-
-  const chain = () => ({
-    select() {
-      return chain();
-    },
-    eq() {
-      return chain();
-    },
-    ilike() {
-      return chain();
-    },
-    limit() {
-      return chain();
-    },
-    async maybeSingle() {
-      return { data: null, error: { message } };
-    },
-    then(onFulfilled?: (value: any) => any, onRejected?: (reason: any) => any) {
-      const value = { data: null, error: { message } } as const;
-      try {
-        return Promise.resolve(onFulfilled ? onFulfilled(value) : (value as any));
-      } catch (err) {
-        return onRejected ? Promise.resolve(onRejected(err)) : Promise.reject(err);
-      }
-    },
-  });
-
-  const from = () => chain();
-
-  if (typeof window !== 'undefined') {
-    // eslint-disable-next-line no-console
-    console.warn('[Supabase] ' + message);
-  }
-
-  return { auth, from } as any;
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('Missing Supabase configuration: VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY');
 }
 
-export const supabase = isSupabaseConfigured
-  ? createClient(supabaseUrl as string, supabaseKey as string)
-  : createNotConfiguredClient();
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/client/pages/administrador/Usuarios.tsx
+++ b/client/pages/administrador/Usuarios.tsx
@@ -22,7 +22,7 @@ export default function UsuariosAdminPage() {
   const [busca, setBusca] = useState("");
   const [usuarios, setUsuarios] = useState<Usuario[]>([]);
   const [abrirNovo, setAbrirNovo] = useState(false);
-  const [novo, setNovo] = useState<{ nome: string; email: string; perfil: PerfilUsuario; ativo: boolean }>({ nome: "", email: "", perfil: "funcionario", ativo: true });
+  const [novo, setNovo] = useState<{ nome: string; email: string; password: string; perfil: PerfilUsuario; ativo: boolean }>({ nome: "", email: "", password: "", perfil: "funcionario", ativo: true });
 
   const [abrirEditar, setAbrirEditar] = useState(false);
   const [alvoEdicao, setAlvoEdicao] = useState<Usuario | null>(null);

--- a/client/pages/administrador/Usuarios.tsx
+++ b/client/pages/administrador/Usuarios.tsx
@@ -54,9 +54,26 @@ export default function UsuariosAdminPage() {
     }
   };
 
-  const criarUsuario = () => {
-    setAbrirNovo(false);
-    toast({ title: "Criação indisponível", description: "Criar usuários requer a API Admin do Supabase (service role)." });
+  const criarUsuario = async () => {
+    if (!novo.nome || !novo.email || !novo.password || novo.password.length < 6) {
+      toast({ title: "Preencha nome, e-mail e senha (mín. 6)" });
+      return;
+    }
+    try {
+      const res = await fetch("/api/admin/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nome: novo.nome, email: novo.email, password: novo.password, perfil: novo.perfil, ativo: novo.ativo }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Erro ao criar usuário");
+      setUsuarios((prev) => [data as any, ...prev]);
+      setAbrirNovo(false);
+      setNovo({ nome: "", email: "", password: "", perfil: "funcionario", ativo: true });
+      toast({ title: "Usuário criado", description: `${data.nome} (${data.perfil})` });
+    } catch (e: any) {
+      toast({ title: "Erro ao criar usuário", description: e?.message || String(e) });
+    }
   };
 
   const handleSair = () => navigate("/");

--- a/client/pages/administrador/Usuarios.tsx
+++ b/client/pages/administrador/Usuarios.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/Header";
 import SidebarAdministrador from "@/components/SidebarAdministrador";

--- a/client/pages/administrador/Usuarios.tsx
+++ b/client/pages/administrador/Usuarios.tsx
@@ -65,8 +65,24 @@ export default function UsuariosAdminPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ nome: novo.nome, email: novo.email, password: novo.password, perfil: novo.perfil, ativo: novo.ativo }),
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data?.error || "Erro ao criar usuário");
+
+      let payload: any = null;
+      let fallbackText: string | null = null;
+      try {
+        payload = await res.clone().json();
+      } catch {}
+      if (!payload) {
+        try {
+          fallbackText = await res.text();
+        } catch {}
+      }
+
+      if (!res.ok) {
+        const msg = (payload && (payload.error || payload.message)) || fallbackText || `${res.status} ${res.statusText}`;
+        throw new Error(msg);
+      }
+
+      const data = payload ?? {};
       setUsuarios((prev) => [data as any, ...prev]);
       setAbrirNovo(false);
       setNovo({ nome: "", email: "", password: "", perfil: "funcionario", ativo: true });
@@ -109,7 +125,7 @@ export default function UsuariosAdminPage() {
           <div className="mx-auto max-w-7xl space-y-6">
             <div>
               <h1 className="mb-2 font-open-sans text-3xl font-bold text-sis-dark-text">Gerenciamento de Usuários</h1>
-              <p className="font-roboto text-sm text-sis-secondary-text">Administre perfis, status de acesso e cadastre novos usuários.</p>
+              <p className="font-roboto text-sm text-sis-secondary-text">Administre perfis, status de acesso e cadastre novos usu��rios.</p>
             </div>
 
             <Card className="border-sis-border bg-white">

--- a/client/pages/administrador/Usuarios.tsx
+++ b/client/pages/administrador/Usuarios.tsx
@@ -119,6 +119,10 @@ export default function UsuariosAdminPage() {
                         <Input type="email" value={novo.email} onChange={(e) => setNovo({ ...novo, email: e.target.value })} />
                       </div>
                       <div>
+                        <Label>Senha (mín. 6)</Label>
+                        <Input type="password" value={novo.password} onChange={(e) => setNovo({ ...novo, password: e.target.value })} />
+                      </div>
+                      <div>
                         <Label>Perfil</Label>
                         <Select value={novo.perfil} onValueChange={(v: PerfilUsuario) => setNovo({ ...novo, perfil: v })}>
                           <SelectTrigger><SelectValue placeholder="Selecione" /></SelectTrigger>

--- a/client/pages/gestor/Funcionario.tsx
+++ b/client/pages/gestor/Funcionario.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";

--- a/client/pages/gestor/Funcionario.tsx
+++ b/client/pages/gestor/Funcionario.tsx
@@ -13,13 +13,26 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  funcionariosMock,
-  type Funcionario,
-  type Classificacao,
-  type StatusProcesso,
-} from "@/data/funcionarios";
 import { fetchEmployeeById } from "@/lib/api";
+
+type Classificacao = "Leve" | "Média" | "Grave" | "Gravíssima";
+type StatusProcesso = "Em Análise" | "Sindicância" | "Aguardando Assinatura" | "Finalizado";
+type Registro = {
+  id: string;
+  dataOcorrencia: string;
+  tipoDesvio: string;
+  classificacao: Classificacao;
+  medidaAplicada: string;
+  status: StatusProcesso;
+};
+type Funcionario = {
+  id: string;
+  nomeCompleto: string;
+  cargo: string;
+  setor: string;
+  gestorDireto: string;
+  historico: Registro[];
+};
 
 const getClassificacaoClasses = (c: Classificacao) => {
   switch (c) {

--- a/client/pages/gestor/Funcionarios.tsx
+++ b/client/pages/gestor/Funcionarios.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";

--- a/client/pages/gestor/Funcionarios.tsx
+++ b/client/pages/gestor/Funcionarios.tsx
@@ -13,13 +13,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { funcionariosMock } from "@/data/funcionarios";
 import { fetchEmployees } from "@/lib/api";
 
 export default function FuncionariosListaPage() {
   const navigate = useNavigate();
   const [busca, setBusca] = useState("");
-  const [employees, setEmployees] = useState<typeof funcionariosMock>(funcionariosMock);
+  const [employees, setEmployees] = useState<any[]>([]);
 
   useEffect(() => {
     let mounted = true;
@@ -44,7 +43,7 @@ export default function FuncionariosListaPage() {
         .toLowerCase()
         .includes(q),
     );
-  }, [busca]);
+  }, [busca, employees]);
 
   const handleSair = () => {
     window.location.href = "/";

--- a/client/pages/gestor/GestorDashboard.tsx
+++ b/client/pages/gestor/GestorDashboard.tsx
@@ -1,8 +1,19 @@
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
 import MetricCard from "@/components/MetricCard";
 import TabelaProcessos from "@/components/TabelaProcessos";
+import { fetchProcesses } from "@/lib/api";
+
+type DashboardProc = {
+  id: string;
+  colaborador: string;
+  tipoDesvio: string;
+  status: { texto: string; cor: "amarelo" | "azul" | "roxo" | "verde" };
+  dataInicio: string;
+  prazo: string;
+};
 
 export default function GestorDashboard() {
   const navigate = useNavigate();
@@ -11,172 +22,108 @@ export default function GestorDashboard() {
   };
 
   const handleSair = () => {
-    console.log("Sair do sistema");
     window.location.href = "/";
   };
 
-  // Dados mockados das métricas
-  const metricas = [
-    {
-      titulo: "Processos Ativos",
-      valor: "14",
-      descricao: "+3% que no mês passado",
-      icon: (
-        <svg
-          className="h-4 w-4"
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+  const [processos, setProcessos] = useState<DashboardProc[]>([]);
+  const [metricas, setMetricas] = useState<Array<{ titulo: string; valor: string; descricao: string; icon: JSX.Element }>>([
+    { titulo: "Processos Ativos", valor: "0", descricao: "", icon: (
+        <svg className="h-4 w-4" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M10.0199 14.01L10.0199 12.67C10.0199 12.137 9.80797 11.6258 9.43103 11.2489C9.10126 10.9191 8.66884 10.7156 8.20882 10.6698L8.00989 10.66L3.98989 10.66C3.45681 10.66 2.94571 10.8719 2.56876 11.2489C2.19181 11.6258 1.97989 12.137 1.97989 12.67L1.97989 14.01C1.97989 14.38 1.67992 14.68 1.30989 14.68C0.939865 14.68 0.639893 14.38 0.639893 14.01L0.639893 12.67C0.639893 11.7815 0.99309 10.9297 1.62134 10.3014C2.24959 9.67323 3.10142 9.32001 3.98989 9.32001L8.00989 9.32001L8.17605 9.32396C9.00404 9.36503 9.78948 9.71249 10.3785 10.3014C11.0067 10.9297 11.3599 11.7815 11.3599 12.67L11.3599 14.01C11.3599 14.38 11.0599 14.68 10.6899 14.68C10.3199 14.68 10.0199 14.38 10.0199 14.01Z" fill="currentColor" />
           <path d="M12.0023 4.67006C12.0023 4.22485 11.8546 3.79211 11.5822 3.43999C11.3438 3.13179 11.0214 2.90044 10.6557 2.7726L10.4967 2.72419L10.4313 2.7039C10.1129 2.58591 9.92945 2.24344 10.0165 1.90763C10.1036 1.5719 10.4301 1.36214 10.7657 1.41363L10.8331 1.42737L10.9665 1.46466C11.6301 1.66632 12.2157 2.06985 12.6415 2.62015C13.0957 3.20706 13.3423 3.92797 13.3423 4.67006C13.3423 5.41216 13.0957 6.13307 12.6415 6.72001C12.1873 7.30686 11.5515 7.72655 10.8331 7.91274C10.4749 8.0056 10.1094 7.7906 10.0165 7.43249C9.92362 7.07437 10.1386 6.70882 10.4967 6.61594C10.9277 6.5042 11.3097 6.25229 11.5822 5.90014C11.8547 5.54802 12.0023 5.11528 12.0023 4.67006Z" fill="currentColor" />
           <path d="M14.005 14.0099L14.005 12.6705L13.9978 12.5044C13.9655 12.1183 13.8224 11.7485 13.5836 11.4405C13.3448 11.1324 13.0224 10.9013 12.6565 10.7738L12.4975 10.7253L12.432 10.705C12.1135 10.5874 11.9299 10.2453 12.0166 9.90941C12.1033 9.57367 12.4295 9.36302 12.7651 9.41414L12.8325 9.42848L12.966 9.4658C13.6299 9.66687 14.2166 10.0693 14.6429 10.6193C15.0976 11.2059 15.3444 11.927 15.345 12.6693L15.345 14.0099C15.3449 14.3799 15.045 14.6799 14.675 14.6799C14.305 14.6799 14.0051 14.3799 14.005 14.0099Z" fill="currentColor" />
           <path d="M8.0099 4.67001C8.0099 3.55992 7.11002 2.66001 5.9999 2.66001C4.88981 2.66001 3.9899 3.55992 3.9899 4.67001C3.9899 5.7801 4.88981 6.68001 5.9999 6.68001C7.11002 6.68001 8.0099 5.7801 8.0099 4.67001ZM9.3499 4.67001C9.3499 6.52016 7.85004 8.02001 5.9999 8.02001C4.14975 8.02001 2.6499 6.52016 2.6499 4.67001C2.6499 2.81986 4.14975 1.32001 5.9999 1.32001C7.85004 1.32001 9.3499 2.81986 9.3499 4.67001Z" fill="currentColor" />
         </svg>
-      ),
-    },
-    {
-      titulo: "Processos Concluídos no Mês",
-      valor: "7",
-      descricao: "Meta: 10 processos",
-      icon: (
-        <svg
-          className="h-4 w-4"
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+      ) },
+    { titulo: "Processos Concluídos", valor: "0", descricao: "", icon: (
+        <svg className="h-4 w-4" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M14.0299 8.00001C14.0299 4.66973 11.3302 1.97 7.99988 1.97C4.66961 1.97 1.96988 4.66973 1.96988 8.00001C1.96988 11.3303 4.66961 14.03 7.99988 14.03C11.3302 14.03 14.0299 11.3303 14.0299 8.00001ZM15.3699 8.00001C15.3699 12.0703 12.0702 15.37 7.99988 15.37C3.92955 15.37 0.629883 12.0703 0.629883 8.00001C0.629883 3.92967 3.92955 0.630005 7.99988 0.630005C12.0702 0.630005 15.3699 3.92967 15.3699 8.00001Z" fill="currentColor" />
           <path d="M9.58727 6.14051C9.85038 5.92587 10.2383 5.94101 10.4836 6.18631C10.7289 6.4316 10.7441 6.81954 10.5294 7.08271L10.4836 7.1337L7.80359 9.8137C7.55831 10.0591 7.17038 10.0742 6.90727 9.85953L6.85622 9.8137L5.5162 8.4737L5.4704 8.42271C5.25577 8.15954 5.2709 7.77161 5.5162 7.52632C5.7615 7.28103 6.14943 7.26589 6.41259 7.48049L6.46362 7.52632L7.3299 8.39256L9.53621 6.18631L9.58727 6.14051Z" fill="currentColor" />
         </svg>
-      ),
-    },
-    {
-      titulo: "Processos Pendentes da Equipe",
-      valor: "5",
-      descricao: "Requere atenção imediata",
-      icon: (
-        <svg
-          className="h-4 w-4"
-          width="15"
-          height="15"
-          viewBox="0 0 15 15"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+      ) },
+    { titulo: "Pendentes da Equipe", valor: "0", descricao: "", icon: (
+        <svg className="h-4 w-4" width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M13.1701 7.50001C13.1701 4.36855 10.6315 1.83001 7.50007 1.83001C4.36862 1.83001 1.83007 4.36855 1.83007 7.50001C1.83007 10.6315 4.36862 13.17 7.50007 13.17C10.6315 13.17 13.1701 10.6315 13.1701 7.50001ZM14.4301 7.50001C14.4301 11.3273 11.3274 14.43 7.50007 14.43C3.67274 14.43 0.570068 11.3273 0.570068 7.50001C0.570068 3.67268 3.67274 0.570007 7.50007 0.570007C11.3274 0.570007 14.4301 3.67268 14.4301 7.50001Z" fill="currentColor" />
           <path d="M6.86011 3.73001C6.86011 3.38207 7.14216 3.10001 7.49011 3.10001C7.83806 3.10001 8.12011 3.38207 8.12011 3.73001V7.12054L10.2919 8.20647L10.3479 8.23841C10.6176 8.40939 10.7196 8.76005 10.5736 9.05181C10.4278 9.34356 10.086 9.47265 9.7874 9.35937L9.72831 9.33354L7.20831 8.07354C6.99493 7.96682 6.86011 7.74865 6.86011 7.51001L6.86011 3.73001Z" fill="currentColor" />
         </svg>
-      ),
-    },
-    {
-      titulo: "Média de Resolução (dias)",
-      valor: "22.5",
-      descricao: "Melhora de 1.2 dias",
-      icon: (
-        <svg
-          className="h-4 w-4"
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
+      ) },
+    { titulo: "Média de Resolução (dias)", valor: "0", descricao: "", icon: (
+        <svg className="h-4 w-4" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M12.67 4.64499C12.9492 4.64499 13.1994 4.81806 13.2975 5.07944L15.3075 10.4394C15.4121 10.7184 15.3197 11.0331 15.0811 11.2115C14.3831 11.733 13.539 12.015 12.67 12.015C11.801 12.015 10.957 11.733 10.259 11.2115C10.0203 11.0331 9.92791 10.7184 10.0326 10.4394L12.0426 5.07944L12.0864 4.98588C12.2038 4.77759 12.4257 4.64499 12.67 4.64499ZM11.4805 10.3943C11.8498 10.5774 12.2557 10.675 12.67 10.675C13.0841 10.675 13.4897 10.5772 13.8589 10.3943L12.67 7.22355L11.4805 10.3943Z" fill="currentColor" />
           <path d="M3.33004 4.64499C3.60926 4.64499 3.85939 4.81806 3.95751 5.07944L5.96751 10.4394C6.07213 10.7184 5.97975 11.0331 5.74113 11.2115C5.04313 11.733 4.19906 12.015 3.33004 12.015C2.46103 12.015 1.61696 11.733 0.918957 11.2115C0.680337 11.0331 0.587958 10.7184 0.692571 10.4394L2.70257 5.07944L2.74641 4.98588C2.86379 4.77759 3.0857 4.64499 3.33004 4.64499ZM2.14053 10.3943C2.50983 10.5774 2.91569 10.675 3.33004 10.675C3.7442 10.675 4.14974 10.5772 4.5189 10.3943L3.33004 7.22355L2.14053 10.3943Z" fill="currentColor" />
           <path d="M11.3501 13.33C11.7201 13.33 12.0201 13.6299 12.0201 14C12.0201 14.37 11.7201 14.67 11.3501 14.67L4.6501 14.67C4.28007 14.67 3.9801 14.37 3.9801 14C3.9801 13.6299 4.28007 13.33 4.6501 13.33L11.3501 13.33Z" fill="currentColor" />
           <path d="M7.33008 14.03L7.33008 1.96999C7.33008 1.59996 7.63004 1.29999 8.00008 1.29999C8.37012 1.29999 8.67008 1.59996 8.67008 1.96999L8.67008 14.03C8.67008 14.4 8.37012 14.7 8.00008 14.7C7.63004 14.7 7.33008 14.4 7.33008 14.03Z" fill="currentColor" />
           <path d="M7.77238 2.69989C7.94384 2.6379 8.13458 2.64808 8.29974 2.73064L8.55032 2.85234C9.83632 3.45673 11.5761 3.99998 12.69 3.99998L14.03 3.99998C14.4001 3.99998 14.7 4.29995 14.7 4.66998C14.7 5.04001 14.4001 5.33998 14.03 5.33998L12.69 5.33998C11.3025 5.33998 9.37194 4.71491 8.00005 4.07326C6.62819 4.71491 4.69759 5.33998 3.31005 5.33998H1.97005C1.60002 5.33998 1.30005 5.04001 1.30005 4.66998C1.30005 4.29995 1.60002 3.99998 1.97005 3.99998L3.31005 3.99998C4.49824 3.99998 6.39831 3.38168 7.70036 2.73064L7.77238 2.69989Z" fill="currentColor" />
         </svg>
-      ),
-    },
-  ];
+      ) },
+  ]);
 
-  // Dados mockados dos processos
-  const processos = [
-    {
-      id: "PROC-001",
-      colaborador: "João Silva",
-      tipoDesvio: "Atraso Injustificado",
-      status: { texto: "Em Análise", cor: "amarelo" as const },
-      dataInicio: "01/05/2024",
-      prazo: "15/05/2024",
-    },
-    {
-      id: "PROC-002",
-      colaborador: "Maria Oliveira",
-      tipoDesvio: "Uso Indevido de Recursos",
-      status: { texto: "Aguardando Evidências", cor: "azul" as const },
-      dataInicio: "05/05/2024",
-      prazo: "20/05/2024",
-    },
-    {
-      id: "PROC-003",
-      colaborador: "Pedro Souza",
-      tipoDesvio: "Conduta Inapropriada",
-      status: { texto: "Aguardando Decisão", cor: "roxo" as const },
-      dataInicio: "10/05/2024",
-      prazo: "25/05/2024",
-    },
-    {
-      id: "PROC-004",
-      colaborador: "Ana Costa",
-      tipoDesvio: "Descumprimento de Normas",
-      status: { texto: "Em Andamento", cor: "verde" as const },
-      dataInicio: "12/05/2024",
-      prazo: "27/05/2024",
-    },
-    {
-      id: "PROC-005",
-      colaborador: "Carlos Santos",
-      tipoDesvio: "Quebra de Confidencialidade",
-      status: { texto: "Em Análise", cor: "amarelo" as const },
-      dataInicio: "15/05/2024",
-      prazo: "30/05/2024",
-    },
-  ];
+  useEffect(() => {
+    let mounted = true;
+    fetchProcesses()
+      .then((list: any[]) => {
+        if (!mounted) return;
+        const itens: DashboardProc[] = (list || []).map((p) => ({
+          id: p.id,
+          colaborador: p.funcionario,
+          tipoDesvio: p.tipoDesvio,
+          status: {
+            texto: p.status,
+            cor:
+              p.status === "Em Análise" ? "amarelo" :
+              p.status === "Sindicância" ? "azul" :
+              p.status === "Aguardando Assinatura" ? "roxo" :
+              "verde",
+          },
+          dataInicio: p.dataAbertura,
+          prazo: "",
+        }));
+        setProcessos(itens);
+
+        const total = list?.length || 0;
+        const concluidos = (list || []).filter((p) => p.status === "Finalizado").length;
+        const ativos = total - concluidos;
+        const pendentes = (list || []).filter((p) => p.status === "Em Análise" || p.status === "Sindicância").length;
+
+        const now = Date.now();
+        const daysArr: number[] = (list || [])
+          .map((p) => (p.createdAt ? Math.max(0, Math.round((now - new Date(p.createdAt).getTime()) / (1000 * 60 * 60 * 24))) : null))
+          .filter((v): v is number => v !== null);
+        const mediaDias = daysArr.length ? (daysArr.reduce((a, b) => a + b, 0) / daysArr.length).toFixed(1) : "0";
+
+        setMetricas((m) => [
+          { ...m[0], valor: String(ativos) },
+          { ...m[1], valor: String(concluidos) },
+          { ...m[2], valor: String(pendentes) },
+          { ...m[3], valor: mediaDias },
+        ]);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setProcessos([]);
+        setMetricas((m) => m.map((x) => ({ ...x, valor: "0" })));
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   return (
     <div className="flex h-screen bg-sis-bg-light">
-      {/* Sidebar */}
       <Sidebar onSair={handleSair} />
-
-      {/* Conteúdo Principal */}
       <div className="flex flex-1 flex-col">
-        {/* Header */}
         <Header onRegistrarDesvio={handleRegistrarDesvio} userType="gestor" />
-
-        {/* Dashboard Content */}
         <div className="flex-1 overflow-auto p-6">
           <div className="mx-auto max-w-7xl">
-            {/* Título Principal */}
             <div className="mb-8">
-              <h1 className="mb-2 font-open-sans text-3xl font-bold text-sis-dark-text">
-                Dashboard do Gestor
-              </h1>
-              <h2 className="font-open-sans text-2xl font-semibold text-sis-dark-text">
-                Visão Geral do Desempenho da Equipe
-              </h2>
+              <h1 className="mb-2 font-open-sans text-3xl font-bold text-sis-dark-text">Dashboard do Gestor</h1>
+              <h2 className="font-open-sans text-2xl font-semibold text-sis-dark-text">Visão Geral do Desempenho da Equipe</h2>
             </div>
-
-            {/* Cards de Métricas */}
             <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
               {metricas.map((metrica, index) => (
-                <MetricCard
-                  key={index}
-                  titulo={metrica.titulo}
-                  valor={metrica.valor}
-                  descricao={metrica.descricao}
-                  icon={metrica.icon}
-                />
+                <MetricCard key={index} titulo={metrica.titulo} valor={metrica.valor} descricao={metrica.descricao} icon={metrica.icon} />
               ))}
             </div>
-
-            {/* Tabela de Processos */}
             <TabelaProcessos processos={processos} />
           </div>
         </div>

--- a/client/pages/gestor/ProcessoAcompanhamento.tsx
+++ b/client/pages/gestor/ProcessoAcompanhamento.tsx
@@ -10,10 +10,20 @@ export default function ProcessoAcompanhamento() {
   const params = useParams<{ id: string }>();
   const id = params.id as string;
 
-  const processo = useMemo(
-    () => processosMock.find((p) => p.id === id),
-    [id],
-  );
+  const [processo, setProcesso] = useState<any | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!id) return;
+    fetchProcessById(id)
+      .then((p) => {
+        if (mounted) setProcesso(p as any);
+      })
+      .catch(() => setProcesso(null));
+    return () => {
+      mounted = false;
+    };
+  }, [id]);
 
   const handleSair = () => {
     window.location.href = "/";

--- a/client/pages/gestor/ProcessoAcompanhamento.tsx
+++ b/client/pages/gestor/ProcessoAcompanhamento.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";

--- a/client/pages/gestor/ProcessoAcompanhamento.tsx
+++ b/client/pages/gestor/ProcessoAcompanhamento.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams } from "react-router-dom";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";
 import { Button } from "@/components/ui/button";
-import { processosMock } from "@/data/processos";
 import { fetchProcessById } from "@/lib/api";
 
 export default function ProcessoAcompanhamento() {

--- a/client/pages/gestor/Processos.tsx
+++ b/client/pages/gestor/Processos.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/Header";
 import Sidebar from "@/components/Sidebar";

--- a/client/pages/gestor/Processos.tsx
+++ b/client/pages/gestor/Processos.tsx
@@ -20,13 +20,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  processosMock,
-  type ProcessoItem,
-  type Classificacao,
-  type StatusAtual,
-} from "@/data/processos";
 import { fetchProcesses } from "@/lib/api";
+
+type Classificacao = "Leve" | "Média" | "Grave" | "Gravíssima";
+type StatusAtual = "Em Análise" | "Sindicância" | "Aguardando Assinatura" | "Finalizado";
+type ProcessoItem = {
+  id: string;
+  funcionario: string;
+  tipoDesvio: string;
+  classificacao: Classificacao;
+  dataAbertura: string;
+  status: StatusAtual;
+};
 
 const getClassificacaoClasses = (c: Classificacao) => {
   switch (c) {
@@ -57,7 +62,7 @@ const getStatusClasses = (s: StatusAtual) => {
 export default function ProcessosPage() {
   const navigate = useNavigate();
   const [busca, setBusca] = useState("");
-  const [processes, setProcesses] = useState<ProcessoItem[]>(processosMock);
+  const [processes, setProcesses] = useState<ProcessoItem[]>([]);
 
   useEffect(() => {
     let mounted = true;
@@ -141,7 +146,7 @@ export default function ProcessosPage() {
             <div className="mb-4 grid grid-cols-1 gap-3 md:grid-cols-4">
               <div className="md:col-span-2">
                 <Input
-                  placeholder="Buscar por funcionário ou ID do processo"
+                  placeholder="Buscar por funcion��rio ou ID do processo"
                   value={busca}
                   onChange={(e) => setBusca(e.target.value)}
                 />

--- a/client/pages/juridico/JuridicoDashboard.tsx
+++ b/client/pages/juridico/JuridicoDashboard.tsx
@@ -3,8 +3,8 @@ import Header from "@/components/Header";
 import SidebarJuridico from "@/components/SidebarJuridico";
 import MetricCard from "@/components/MetricCard";
 import { Badge } from "@/components/ui/badge";
-import { legalCasesAwaitingMock, type LegalReviewStatus } from "@/data/legal";
 import { Button } from "@/components/ui/button";
+import { fetchProcesses } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Table,
@@ -14,11 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  processosJuridicosMock,
-  atividadesRecentesMock,
-  type StatusJuridico,
-} from "@/data/juridico";
+type StatusJuridico = "Em Revisão" | "Pendente" | "Finalizado" | "Aguardando Análise";
 
 const getStatusJuridicoClasses = (s: StatusJuridico) => {
   switch (s) {
@@ -33,9 +29,10 @@ const getStatusJuridicoClasses = (s: StatusJuridico) => {
   }
 };
 
-function getLegalStatusClasses(s: LegalReviewStatus) {
+type StatusAtual = "Em Análise" | "Sindicância" | "Aguardando Assinatura" | "Finalizado";
+function getStatusClasses(s: StatusAtual) {
   switch (s) {
-    case "Aguardando Parecer Jurídico":
+    case "Em Análise":
       return "bg-status-yellow-bg border-status-yellow-border text-status-yellow-text";
     case "Em Revisão":
       return "bg-status-blue-bg border-status-blue-border text-status-blue-text";
@@ -46,6 +43,15 @@ function getLegalStatusClasses(s: LegalReviewStatus) {
 
 function AwaitingLegalTable() {
   const navigate = useNavigate();
+  const [processos, setProcessos] = useState<{ id: string; funcionario: string; tipoDesvio: string; classificacao: string; dataAbertura: string; status: StatusAtual; }[]>([]);
+  useEffect(() => {
+    let mounted = true;
+    fetchProcesses().then((data) => {
+      if (mounted) setProcessos((data as any) || []);
+    });
+    return () => { mounted = false; };
+  }, []);
+
   return (
     <div className="rounded-md border border-sis-border">
       <Table>
@@ -55,23 +61,23 @@ function AwaitingLegalTable() {
             <TableHead className="w-[20%]">Funcionário</TableHead>
             <TableHead className="w-[18%]">Tipo de Desvio</TableHead>
             <TableHead className="w-[14%]">Classificação</TableHead>
-            <TableHead className="w-[16%]">Data de Encaminhamento</TableHead>
+            <TableHead className="w-[16%]">Data de Abertura</TableHead>
             <TableHead className="w-[10%]">Status</TableHead>
             <TableHead className="w-[8%]">Ação</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
-          {legalCasesAwaitingMock
-            .filter((c) => c.status === "Aguardando Parecer Jurídico")
+          {processos
+            .filter((c) => c.status === "Sindicância")
             .map((c) => (
               <TableRow key={c.id}>
                 <TableCell className="font-medium">{c.id}</TableCell>
-                <TableCell className="truncate">{c.employeeName}</TableCell>
-                <TableCell className="truncate">{c.deviationType}</TableCell>
-                <TableCell>{c.classification}</TableCell>
-                <TableCell className="text-sis-secondary-text">{c.referralDate}</TableCell>
+                <TableCell className="truncate">{c.funcionario}</TableCell>
+                <TableCell className="truncate">{c.tipoDesvio}</TableCell>
+                <TableCell>{c.classificacao}</TableCell>
+                <TableCell className="text-sis-secondary-text">{c.dataAbertura}</TableCell>
                 <TableCell>
-                  <Badge className={`border ${getLegalStatusClasses(c.status)}`}>{c.status}</Badge>
+                  <Badge className={`border ${getStatusClasses(c.status)}`}>{c.status}</Badge>
                 </TableCell>
                 <TableCell>
                   <Button size="sm" onClick={() => navigate(`/juridico/processos/${c.id}`)}>
@@ -257,17 +263,8 @@ export default function JuridicoDashboard() {
                     <CardTitle className="text-xl">Atividades Recentes</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <div className="space-y-6">
-                      {atividadesRecentesMock.map((atividade) => (
-                        <div key={atividade.id} className="space-y-2">
-                          <p className="font-roboto text-sm text-sis-dark-text leading-5">
-                            {atividade.descricao}
-                          </p>
-                          <p className="font-roboto text-xs text-sis-secondary-text">
-                            {atividade.tempo}
-                          </p>
-                        </div>
-                      ))}
+                    <div className="space-y-6 text-sm text-sis-secondary-text">
+                      <p>Nenhuma atividade recente.</p>
                     </div>
                   </CardContent>
                 </Card>

--- a/client/pages/juridico/JuridicoDashboard.tsx
+++ b/client/pages/juridico/JuridicoDashboard.tsx
@@ -34,7 +34,7 @@ function getStatusClasses(s: StatusAtual) {
   switch (s) {
     case "Em Análise":
       return "bg-status-yellow-bg border-status-yellow-border text-status-yellow-text";
-    case "Em Revisão":
+    case "Sindicância":
       return "bg-status-blue-bg border-status-blue-border text-status-blue-text";
     case "Finalizado":
       return "bg-status-green-bg border-status-green-border text-status-green-text";

--- a/client/pages/juridico/JuridicoDashboard.tsx
+++ b/client/pages/juridico/JuridicoDashboard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/Header";
 import SidebarJuridico from "@/components/SidebarJuridico";

--- a/client/pages/juridico/ProcessosAguardandoAnalise.tsx
+++ b/client/pages/juridico/ProcessosAguardandoAnalise.tsx
@@ -15,8 +15,10 @@ function getStatusClasses(s: StatusAtual) {
   switch (s) {
     case "Em Análise":
       return "bg-status-yellow-bg border-status-yellow-border text-status-yellow-text";
-    case "Em Revisão":
+    case "Sindicância":
       return "bg-status-blue-bg border-status-blue-border text-status-blue-text";
+    case "Aguardando Assinatura":
+      return "bg-status-purple-bg border-status-purple-border text-status-purple-text";
     case "Finalizado":
       return "bg-status-green-bg border-status-green-border text-status-green-text";
   }

--- a/client/pages/juridico/ProcessosAguardandoAnalise.tsx
+++ b/client/pages/juridico/ProcessosAguardandoAnalise.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/Header";
 import SidebarJuridico from "@/components/SidebarJuridico";

--- a/client/pages/juridico/Relatorios.tsx
+++ b/client/pages/juridico/Relatorios.tsx
@@ -130,9 +130,9 @@ export default function Relatorios() {
       d.classificacao,
       d.dataAbertura,
       d.status,
-      d.legalDecisionResult ?? "",
-      d.legalDecisionMeasure ?? "",
-      d.decisionDate ?? "",
+      d.status,
+      d.resolucao ?? "",
+      d.dataAbertura,
     ]);
     const csv = [cabecalho, ...linhas]
       .map((r) => r.map((c) => `"${String(c).replace(/\"/g, '""')}"`).join(","))

--- a/client/pages/juridico/Relatorios.tsx
+++ b/client/pages/juridico/Relatorios.tsx
@@ -41,6 +41,7 @@ const statusOpcoes: ("todos" | StatusAtual)[] = [
   "todos",
   "Em Análise",
   "Sindicância",
+  "Aguardando Assinatura",
   "Finalizado",
 ];
 

--- a/client/pages/juridico/Relatorios.tsx
+++ b/client/pages/juridico/Relatorios.tsx
@@ -84,8 +84,8 @@ export default function Relatorios() {
 
   const metricas = useMemo(() => {
     const total = dados.length;
-    const aguardando = dados.filter((d) => d.status === "Aguardando Parecer Jurídico").length;
-    const revisao = dados.filter((d) => d.status === "Em Revisão").length;
+    const aguardando = dados.filter((d) => d.status === "Em Análise").length;
+    const revisao = dados.filter((d) => d.status === "Sindicância").length;
     const finalizado = dados.filter((d) => d.status === "Finalizado").length;
     return { total, aguardando, revisao, finalizado };
   }, [dados]);
@@ -102,7 +102,8 @@ export default function Relatorios() {
   const distribuicaoClassificacao = useMemo(() => {
     const mapa = new Map<string, number>();
     dados.forEach((d) => {
-      mapa.set(d.classification, (mapa.get(d.classification) || 0) + 1);
+      const cls = d.classificacao as string;
+      mapa.set(cls, (mapa.get(cls) || 0) + 1);
     });
     return Array.from(mapa.entries()).map(([name, value]) => ({ name, value }));
   }, [dados]);
@@ -124,10 +125,10 @@ export default function Relatorios() {
     ];
     const linhas = dados.map((d) => [
       d.id,
-      d.employeeName,
-      d.deviationType,
-      d.classification,
-      d.referralDate,
+      d.funcionario,
+      d.tipoDesvio,
+      d.classificacao,
+      d.dataAbertura,
       d.status,
       d.legalDecisionResult ?? "",
       d.legalDecisionMeasure ?? "",
@@ -318,7 +319,7 @@ export default function Relatorios() {
                         <TableHead className="w-[20%]">Funcionário</TableHead>
                         <TableHead className="w-[18%]">Tipo de Desvio</TableHead>
                         <TableHead className="w-[14%]">Classificação</TableHead>
-                        <TableHead className="w-[16%]">Data de Encaminhamento</TableHead>
+                        <TableHead className="w-[16%]">Data de Abertura</TableHead>
                         <TableHead className="w-[10%]">Status</TableHead>
                         <TableHead className="w-[8%]">Ação</TableHead>
                       </TableRow>
@@ -334,12 +335,12 @@ export default function Relatorios() {
                         dados.map((c) => (
                           <TableRow key={c.id} className="hover:bg-gray-50">
                             <TableCell className="font-medium">{c.id}</TableCell>
-                            <TableCell className="truncate">{c.employeeName}</TableCell>
-                            <TableCell className="truncate">{c.deviationType}</TableCell>
-                            <TableCell>{c.classification}</TableCell>
-                            <TableCell className="text-sis-secondary-text">{c.referralDate}</TableCell>
+                            <TableCell className="truncate">{c.funcionario}</TableCell>
+                            <TableCell className="truncate">{c.tipoDesvio}</TableCell>
+                            <TableCell>{c.classificacao}</TableCell>
+                            <TableCell className="text-sis-secondary-text">{c.dataAbertura}</TableCell>
                             <TableCell>
-                              <Badge className={`border ${getLegalStatusClasses(c.status)}`}>{c.status}</Badge>
+                              <Badge className={`border ${getStatusClasses(c.status)}`}>{c.status}</Badge>
                             </TableCell>
                             <TableCell>
                               <Button size="sm" onClick={() => navegar(`/juridico/processos/${c.id}`)}>Abrir</Button>

--- a/client/pages/juridico/Relatorios.tsx
+++ b/client/pages/juridico/Relatorios.tsx
@@ -28,10 +28,12 @@ type Classificacao = "Leve" | "Média" | "Grave" | "Gravíssima";
 type StatusAtual = "Em Análise" | "Sindicância" | "Aguardando Assinatura" | "Finalizado";
 function getStatusClasses(s: StatusAtual) {
   switch (s) {
-    case "Aguardando Parecer Jurídico":
+    case "Em Análise":
       return "bg-status-yellow-bg border-status-yellow-border text-status-yellow-text";
-    case "Em Revisão":
+    case "Sindicância":
       return "bg-status-blue-bg border-status-blue-border text-status-blue-text";
+    case "Aguardando Assinatura":
+      return "bg-status-purple-bg border-status-purple-border text-status-purple-text";
     case "Finalizado":
       return "bg-status-green-bg border-status-green-border text-status-green-text";
   }

--- a/client/pages/juridico/Relatorios.tsx
+++ b/client/pages/juridico/Relatorios.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { legalCasesAwaitingMock, type LegalReviewStatus } from "@/data/legal";
+import { fetchProcesses } from "@/lib/api";
 import {
   PieChart,
   Pie,
@@ -24,7 +24,9 @@ import {
 } from "recharts";
 import { FileText, Clock, CheckCircle2, PieChart as PieChartIcon, BarChart3, Calendar, Search, Download } from "lucide-react";
 
-function getLegalStatusClasses(s: LegalReviewStatus) {
+type Classificacao = "Leve" | "Média" | "Grave" | "Gravíssima";
+type StatusAtual = "Em Análise" | "Sindicância" | "Aguardando Assinatura" | "Finalizado";
+function getStatusClasses(s: StatusAtual) {
   switch (s) {
     case "Aguardando Parecer Jurídico":
       return "bg-status-yellow-bg border-status-yellow-border text-status-yellow-text";
@@ -35,10 +37,10 @@ function getLegalStatusClasses(s: LegalReviewStatus) {
   }
 }
 
-const statusOpcoes: ("todos" | LegalReviewStatus)[] = [
+const statusOpcoes: ("todos" | StatusAtual)[] = [
   "todos",
-  "Aguardando Parecer Jurídico",
-  "Em Revisão",
+  "Em Análise",
+  "Sindicância",
   "Finalizado",
 ];
 

--- a/client/pages/juridico/Relatorios.tsx
+++ b/client/pages/juridico/Relatorios.tsx
@@ -52,7 +52,7 @@ export default function Relatorios() {
   const [dataInicio, setDataInicio] = useState("");
   const [dataFim, setDataFim] = useState("");
 
-  const [processos, setProcessos] = useState<{ id: string; funcionario: string; tipoDesvio: string; classificacao: Classificacao; dataAbertura: string; status: StatusAtual; }[]>([]);
+  const [processos, setProcessos] = useState<{ id: string; funcionario: string; tipoDesvio: string; classificacao: Classificacao; dataAbertura: string; status: StatusAtual; resolucao?: string }[]>([]);
 
   useEffect(() => {
     let mounted = true;

--- a/client/pages/juridico/Relatorios.tsx
+++ b/client/pages/juridico/Relatorios.tsx
@@ -51,26 +51,36 @@ export default function Relatorios() {
   const [dataInicio, setDataInicio] = useState("");
   const [dataFim, setDataFim] = useState("");
 
+  const [processos, setProcessos] = useState<{ id: string; funcionario: string; tipoDesvio: string; classificacao: Classificacao; dataAbertura: string; status: StatusAtual; }[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    fetchProcesses().then((data) => {
+      if (mounted) setProcessos((data as any) || []);
+    });
+    return () => { mounted = false; };
+  }, []);
+
   const dados = useMemo(() => {
-    const base = legalCasesAwaitingMock;
+    const base = processos;
     const porStatus = statusFiltro === "todos" ? base : base.filter((c) => c.status === statusFiltro);
     const porBusca = !busca.trim()
       ? porStatus
       : porStatus.filter(
           (c) =>
             c.id.toLowerCase().includes(busca.toLowerCase()) ||
-            c.employeeName.toLowerCase().includes(busca.toLowerCase()) ||
-            c.deviationType.toLowerCase().includes(busca.toLowerCase()) ||
-            c.classification.toLowerCase().includes(busca.toLowerCase()),
+            c.funcionario.toLowerCase().includes(busca.toLowerCase()) ||
+            c.tipoDesvio.toLowerCase().includes(busca.toLowerCase()) ||
+            (c.classificacao as string).toLowerCase().includes(busca.toLowerCase()),
         );
     const porPeriodo = porBusca.filter((c) => {
-      const d = new Date(c.referralDate);
+      const d = new Date(c.dataAbertura);
       const okInicio = dataInicio ? d >= new Date(dataInicio) : true;
       const okFim = dataFim ? d <= new Date(dataFim) : true;
       return okInicio && okFim;
     });
     return porPeriodo;
-  }, [busca, statusFiltro, dataInicio, dataFim]);
+  }, [busca, statusFiltro, dataInicio, dataFim, processos]);
 
   const metricas = useMemo(() => {
     const total = dados.length;

--- a/client/pages/juridico/Relatorios.tsx
+++ b/client/pages/juridico/Relatorios.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/Header";
 import SidebarJuridico from "@/components/SidebarJuridico";

--- a/client/pages/juridico/RevisaoProcessoJuridico.tsx
+++ b/client/pages/juridico/RevisaoProcessoJuridico.tsx
@@ -17,18 +17,21 @@ export default function RevisaoProcessoJuridico() {
   const { toast } = useToast();
 
   const idProcesso = parametros.id as string;
-  const processoJuridico = useMemo(() => legalCasesAwaitingMock.find((c) => c.id === idProcesso), [idProcesso]);
+  const [processoJuridico, setProcessoJuridico] = useState<any | null>(null);
   const somenteVisualizacao = processoJuridico?.status === "Finalizado";
 
   const [parecerJuridico, setParecerJuridico] = useState<string>("");
-  const [arquivosEnviados, setArquivosEnviados] = useState<File[]>([]);
   const [decisao, setDecisao] = useState<string>("");
   const [medidaRecomendada, setMedidaRecomendada] = useState<string>("");
 
-  const aoAlterarArquivos = (files: FileList | null) => {
-    if (!files) return;
-    setArquivosEnviados(Array.from(files));
-  };
+  useEffect(() => {
+    let mounted = true;
+    if (!idProcesso) return;
+    fetchProcessById(idProcesso)
+      .then((p) => { if (mounted) setProcessoJuridico(p as any); })
+      .catch(() => setProcessoJuridico(null));
+    return () => { mounted = false; };
+  }, [idProcesso]);
 
   const aoFinalizar = () => {
     if (!decisao) {
@@ -132,7 +135,7 @@ export default function RevisaoProcessoJuridico() {
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div>
-                      <Label className="mb-2 block text-xs text-sis-secondary-text">Parecer Jur��dico</Label>
+                      <Label className="mb-2 block text-xs text-sis-secondary-text">Parecer Jurídico</Label>
                       {somenteVisualizacao ? (
                         <div
                           className="min-h-[120px] rounded-md border border-sis-border bg-gray-50 p-3 text-sm"

--- a/client/pages/juridico/RevisaoProcessoJuridico.tsx
+++ b/client/pages/juridico/RevisaoProcessoJuridico.tsx
@@ -90,42 +90,26 @@ export default function RevisaoProcessoJuridico() {
                     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                       <div>
                         <Label className="text-xs text-sis-secondary-text">Funcionário</Label>
-                        <p className="font-medium text-sis-dark-text">{processoJuridico.employeeName}</p>
+                        <p className="font-medium text-sis-dark-text">{processoJuridico?.funcionario}</p>
                       </div>
                       <div>
-                        <Label className="text-xs text-sis-secondary-text">Data da Ocorrência</Label>
-                        <p className="font-medium text-sis-dark-text">{processoJuridico.occurrenceDate}</p>
+                        <Label className="text-xs text-sis-secondary-text">Data de Abertura</Label>
+                        <p className="font-medium text-sis-dark-text">{processoJuridico?.dataAbertura}</p>
                       </div>
                       <div>
                         <Label className="text-xs text-sis-secondary-text">Tipo de Desvio</Label>
-                        <p className="font-medium text-sis-dark-text">{processoJuridico.deviationType}</p>
+                        <p className="font-medium text-sis-dark-text">{processoJuridico?.tipoDesvio}</p>
                       </div>
                       <div>
                         <Label className="text-xs text-sis-secondary-text">Classificação</Label>
-                        <p className="font-medium text-sis-dark-text">{processoJuridico.classification}</p>
+                        <p className="font-medium text-sis-dark-text">{processoJuridico?.classificacao}</p>
                       </div>
                       <div>
-                        <Label className="text-xs text-sis-secondary-text">Data de Encaminhamento</Label>
-                        <p className="font-medium text-sis-dark-text">{processoJuridico.referralDate}</p>
+                        <Label className="text-xs text-sis-secondary-text">Data de Abertura</Label>
+                        <p className="font-medium text-sis-dark-text">{processoJuridico?.dataAbertura}</p>
                       </div>
                     </div>
-                    <div>
-                      <Label className="text-xs text-sis-secondary-text">Descrição Detalhada (Gestor)</Label>
-                      <p className="text-sm text-sis-dark-text">{processoJuridico.managerDescription}</p>
-                    </div>
-                    <div>
-                      <Label className="text-xs text-sis-secondary-text">Documentos Anexados (Gestor)</Label>
-                      <ul className="list-disc pl-5 text-sm">
-                        {processoJuridico.managerAttachments.map((a) => (
-                          <li key={a.name}>
-                            <a href={a.url} className="text-blue-600 hover:underline" target="_blank" rel="noreferrer">
-                              {a.name}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  </CardContent>
+                                      </CardContent>
                 </Card>
 
                 {/* 2. Análise Jurídica / Sindicância */}

--- a/client/pages/juridico/RevisaoProcessoJuridico.tsx
+++ b/client/pages/juridico/RevisaoProcessoJuridico.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import RichTextEditor from "@/components/RichTextEditor";
 import { useToast } from "@/hooks/use-toast";
+import { useEffect, useState, useMemo } from "react";
 import { fetchProcessById } from "@/lib/api";
 
 export default function RevisaoProcessoJuridico() {

--- a/client/pages/juridico/RevisaoProcessoJuridico.tsx
+++ b/client/pages/juridico/RevisaoProcessoJuridico.tsx
@@ -8,8 +8,8 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import RichTextEditor from "@/components/RichTextEditor";
-import { legalCasesAwaitingMock } from "@/data/legal";
 import { useToast } from "@/hooks/use-toast";
+import { fetchProcessById } from "@/lib/api";
 
 export default function RevisaoProcessoJuridico() {
   const navegar = useNavigate();
@@ -132,7 +132,7 @@ export default function RevisaoProcessoJuridico() {
                   </CardHeader>
                   <CardContent className="space-y-4">
                     <div>
-                      <Label className="mb-2 block text-xs text-sis-secondary-text">Parecer Jurídico</Label>
+                      <Label className="mb-2 block text-xs text-sis-secondary-text">Parecer Jur��dico</Label>
                       {somenteVisualizacao ? (
                         <div
                           className="min-h-[120px] rounded-md border border-sis-border bg-gray-50 p-3 text-sm"

--- a/client/pages/juridico/RevisaoProcessoJuridico.tsx
+++ b/client/pages/juridico/RevisaoProcessoJuridico.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Header from "@/components/Header";
 import SidebarJuridico from "@/components/SidebarJuridico";
@@ -9,7 +9,6 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import RichTextEditor from "@/components/RichTextEditor";
 import { useToast } from "@/hooks/use-toast";
-import { useEffect, useState, useMemo } from "react";
 import { fetchProcessById } from "@/lib/api";
 
 export default function RevisaoProcessoJuridico() {

--- a/client/pages/juridico/RevisaoProcessoJuridico.tsx
+++ b/client/pages/juridico/RevisaoProcessoJuridico.tsx
@@ -160,15 +160,15 @@ export default function RevisaoProcessoJuridico() {
                         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                           <div>
                             <Label className="text-xs text-sis-secondary-text">Resultado da Análise</Label>
-                            <p className="font-medium text-sis-dark-text">{processoJuridico?.legalDecisionResult || "—"}</p>
+                            <p className="font-medium text-sis-dark-text">{processoJuridico?.status || "—"}</p>
                           </div>
                           <div>
                             <Label className="text-xs text-sis-secondary-text">Medida Recomendada/Aplicada</Label>
-                            <p className="font-medium text-sis-dark-text">{processoJuridico?.legalDecisionMeasure ?? "—"}</p>
+                            <p className="font-medium text-sis-dark-text">{processoJuridico?.resolucao || "—"}</p>
                           </div>
                           <div>
                             <Label className="text-xs text-sis-secondary-text">Data da Decisão</Label>
-                            <p className="font-medium text-sis-dark-text">{processoJuridico?.decisionDate || "—"}</p>
+                            <p className="font-medium text-sis-dark-text">{processoJuridico?.dataAbertura || "—"}</p>
                           </div>
                         </div>
                         <div className="flex gap-3 pt-2">

--- a/client/pages/juridico/RevisaoProcessoJuridico.tsx
+++ b/client/pages/juridico/RevisaoProcessoJuridico.tsx
@@ -133,19 +133,6 @@ export default function RevisaoProcessoJuridico() {
                         />
                       )}
                     </div>
-                    {!somenteVisualizacao && (
-                      <div>
-                        <Label className="mb-2 block text-xs text-sis-secondary-text">Anexar Documentos da Sindicância</Label>
-                        <Input type="file" multiple onChange={(e) => aoAlterarArquivos(e.target.files)} />
-                        {arquivosEnviados.length > 0 && (
-                          <ul className="mt-2 list-disc pl-5 text-sm">
-                            {arquivosEnviados.map((f) => (
-                              <li key={f.name}>{f.name}</li>
-                            ))}
-                          </ul>
-                        )}
-                      </div>
-                    )}
                   </CardContent>
                 </Card>
 

--- a/client/pages/juridico/TodosProcessos.tsx
+++ b/client/pages/juridico/TodosProcessos.tsx
@@ -121,12 +121,12 @@ export default function TodosProcessos() {
                               {c.id}
                             </button>
                           </TableCell>
-                          <TableCell className="truncate">{c.employeeName}</TableCell>
-                          <TableCell className="truncate">{c.deviationType}</TableCell>
-                          <TableCell>{c.classification}</TableCell>
-                          <TableCell className="text-sis-secondary-text">{c.referralDate}</TableCell>
+                          <TableCell className="truncate">{c.funcionario}</TableCell>
+                          <TableCell className="truncate">{c.tipoDesvio}</TableCell>
+                          <TableCell>{c.classificacao}</TableCell>
+                          <TableCell className="text-sis-secondary-text">{c.dataAbertura}</TableCell>
                           <TableCell>
-                            <Badge className={`border ${getLegalStatusClasses(c.status)}`}>{c.status}</Badge>
+                            <Badge className={`border ${getStatusClasses(c.status)}`}>{c.status}</Badge>
                           </TableCell>
                           <TableCell>
                             {c.status === "Finalizado" ? (

--- a/client/pages/juridico/TodosProcessos.tsx
+++ b/client/pages/juridico/TodosProcessos.tsx
@@ -37,21 +37,31 @@ export default function TodosProcessos() {
   const [busca, setBusca] = useState("");
   const [statusFiltro, setStatusFiltro] = useState<(typeof statusOpcoes)[number]>("todos");
 
-  // No momento usamos o dataset legalCasesAwaitingMock como fonte base
+  const [processos, setProcessos] = useState<{ id: string; funcionario: string; tipoDesvio: string; classificacao: Classificacao; dataAbertura: string; status: StatusAtual; }[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    fetchProcesses().then((data) => {
+      if (mounted) setProcessos((data as any) || []);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   const itens = useMemo(() => {
-    const base = legalCasesAwaitingMock;
-    const filtradoStatus =
-      statusFiltro === "todos" ? base : base.filter((c) => c.status === statusFiltro);
+    const base = processos;
+    const filtradoStatus = statusFiltro === "todos" ? base : base.filter((c) => c.status === statusFiltro);
     if (!busca.trim()) return filtradoStatus;
     const q = busca.toLowerCase();
     return filtradoStatus.filter(
       (c) =>
         c.id.toLowerCase().includes(q) ||
-        c.employeeName.toLowerCase().includes(q) ||
-        c.deviationType.toLowerCase().includes(q) ||
-        c.classification.toLowerCase().includes(q),
+        c.funcionario.toLowerCase().includes(q) ||
+        c.tipoDesvio.toLowerCase().includes(q) ||
+        (c.classificacao as string).toLowerCase().includes(q),
     );
-  }, [busca, statusFiltro]);
+  }, [busca, statusFiltro, processos]);
 
   const aoSair = () => {
     window.location.href = "/";

--- a/client/pages/juridico/TodosProcessos.tsx
+++ b/client/pages/juridico/TodosProcessos.tsx
@@ -23,10 +23,10 @@ function getStatusClasses(s: StatusAtual) {
   }
 }
 
-const statusOpcoes: ("todos" | LegalReviewStatus)[] = [
+const statusOpcoes: ("todos" | StatusAtual)[] = [
   "todos",
-  "Aguardando Parecer Jurídico",
-  "Em Revisão",
+  "Em Análise",
+  "Sindicância",
   "Finalizado",
 ];
 

--- a/client/pages/juridico/TodosProcessos.tsx
+++ b/client/pages/juridico/TodosProcessos.tsx
@@ -8,9 +8,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { legalCasesAwaitingMock, type LegalReviewStatus } from "@/data/legal";
+import { fetchProcesses } from "@/lib/api";
 
-function getLegalStatusClasses(s: LegalReviewStatus) {
+type Classificacao = "Leve" | "Média" | "Grave" | "Gravíssima";
+type StatusAtual = "Em Análise" | "Sindicância" | "Aguardando Assinatura" | "Finalizado";
+function getStatusClasses(s: StatusAtual) {
   switch (s) {
     case "Aguardando Parecer Jurídico":
       return "bg-status-yellow-bg border-status-yellow-border text-status-yellow-text";

--- a/client/pages/juridico/TodosProcessos.tsx
+++ b/client/pages/juridico/TodosProcessos.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "@/components/Header";
 import SidebarJuridico from "@/components/SidebarJuridico";

--- a/client/pages/juridico/TodosProcessos.tsx
+++ b/client/pages/juridico/TodosProcessos.tsx
@@ -14,10 +14,12 @@ type Classificacao = "Leve" | "Média" | "Grave" | "Gravíssima";
 type StatusAtual = "Em Análise" | "Sindicância" | "Aguardando Assinatura" | "Finalizado";
 function getStatusClasses(s: StatusAtual) {
   switch (s) {
-    case "Aguardando Parecer Jurídico":
+    case "Em Análise":
       return "bg-status-yellow-bg border-status-yellow-border text-status-yellow-text";
-    case "Em Revisão":
+    case "Sindicância":
       return "bg-status-blue-bg border-status-blue-border text-status-blue-text";
+    case "Aguardando Assinatura":
+      return "bg-status-purple-bg border-status-purple-border text-status-purple-text";
     case "Finalizado":
       return "bg-status-green-bg border-status-green-border text-status-green-text";
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,5 +19,9 @@ export function createServer() {
 
   app.get("/api/demo", handleDemo);
 
+  // Admin endpoints
+  const { createUserAndProfile } = await import("./routes/admin");
+  app.post("/api/admin/users", createUserAndProfile as any);
+
   return app;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import { handleDemo } from "./routes/demo";
+import { createUserAndProfile } from "./routes/admin";
 
 export function createServer() {
   const app = express();

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,7 +21,6 @@ export function createServer() {
   app.get("/api/demo", handleDemo);
 
   // Admin endpoints
-  const { createUserAndProfile } = await import("./routes/admin");
   app.post("/api/admin/users", createUserAndProfile as any);
 
   return app;

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -1,0 +1,53 @@
+import type { RequestHandler } from "express";
+import { createClient } from "@supabase/supabase-js";
+
+function getAdminClient() {
+  const url = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) return null;
+  return createClient(url, serviceKey, { auth: { persistSession: false } });
+}
+
+export const createUserAndProfile: RequestHandler = async (req, res) => {
+  try {
+    const { nome, email, password, perfil, ativo } = req.body as {
+      nome: string;
+      email: string;
+      password: string;
+      perfil: "administrador" | "gestor" | "juridico" | "funcionario";
+      ativo: boolean;
+    };
+
+    if (!nome || !email || !password || !perfil) {
+      return res.status(400).json({ error: "Campos obrigatórios: nome, email, password, perfil" });
+    }
+
+    const admin = getAdminClient();
+    if (!admin) {
+      return res.status(500).json({ error: "SUPABASE_SERVICE_ROLE_KEY ausente no servidor" });
+    }
+
+    const { data: created, error: createErr } = await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { nome, perfil, ativo },
+    });
+    if (createErr) return res.status(400).json({ error: createErr.message });
+
+    const user = created.user;
+    if (!user) return res.status(500).json({ error: "Falha ao criar usuário" });
+
+    const { error: profileErr } = await admin.from("profiles").insert({
+      id: user.id,
+      nome,
+      perfil,
+      ativo,
+    } as any);
+    if (profileErr) return res.status(400).json({ error: profileErr.message });
+
+    return res.json({ id: user.id, nome, email, perfil, ativo, criadoEm: new Date().toISOString() });
+  } catch (e: any) {
+    return res.status(500).json({ error: e?.message || String(e) });
+  }
+};


### PR DESCRIPTION
## Purpose
The user was experiencing a "Failed to execute 'json' on 'Response': body stream already read" error while working with Supabase API calls. They also provided a Supabase service role key to enable proper API functionality. The changes aim to resolve API issues and implement user management capabilities.

## Code changes
- **Removed generic type parameters** from Supabase `.from()` calls to prevent TypeScript/response parsing conflicts
- **Added new API functions** `updateProfile()` and `updateProcess()` for data manipulation
- **Enhanced process data structure** with `createdAt` and `resolucao` fields
- **Implemented user management system** with create/update functionality in admin pages
- **Added server-side user creation endpoint** using Supabase admin client with service role key
- **Improved error handling** and configuration validation for Supabase client
- **Updated UI components** to use real API data instead of mock data
- **Fixed data mapping** in legal process pages to use correct field namesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4d2b2388e62a49f18f33b7655da2f5a6/glow-haven)

👀 [Preview Link](https://4d2b2388e62a49f18f33b7655da2f5a6-glow-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4d2b2388e62a49f18f33b7655da2f5a6</projectId>-->
<!--<branchName>glow-haven</branchName>-->